### PR TITLE
add verboseLogging flag, which defaults to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ var etrade = require('etrade');
 var configuration = 
 {
   useSandbox : true|false, // true if not provided
+  verboseLogging: true|false, //true if not provided
   key : 'your_key',
   secret : 'your_secret'
 }

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ var etrade = require('etrade');
 var configuration = 
 {
   useSandbox : true|false, // true if not provided
-  verboseLogging: true|false, // true if not provided
   key : 'your_key',
-  secret : 'your_secret'
+  secret : 'your_secret',
+  verboseLogging: true|false // true if not provided
 }
 
 var et = new etrade(configuration);

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ var etrade = require('etrade');
 var configuration = 
 {
   useSandbox : true|false, // true if not provided
-  verboseLogging: true|false, //true if not provided
+  verboseLogging: true|false, // true if not provided
   key : 'your_key',
   secret : 'your_secret'
 }

--- a/lib/etrade.js
+++ b/lib/etrade.js
@@ -20,8 +20,10 @@ module.exports = exports = function(options)
         throw Error("The etrade module requires specification of an API secret");
     if (!options.hasOwnProperty("useSandbox"))
         options.useSandbox = true;
+    if (!options.hasOwnProperty("verbose"))
+        options.verbose = false;
 
-    var configurations = 
+    var configurations =
     {
             "base" : {
                 "oauth" : {
@@ -77,7 +79,7 @@ module.exports = exports = function(options)
     this.configuration.key = options.key;
     this.configuration.secret = options.secret;
     this.authorized = false;
-    
+
     this.crypto = crypto;
     this.oauth_sign = oauth_sign;
     this.querystring = querystring;
@@ -92,14 +94,14 @@ var modules = [require('./authorization.js'),
                require('./market.js'),
                require('./order.js')]; // List of E*TRADE modules
 for (var moduleIndex = 0; moduleIndex < modules.length; ++moduleIndex)
-    for (var funcName in modules[moduleIndex]) 
+    for (var funcName in modules[moduleIndex])
         exports.prototype[funcName] = modules[moduleIndex][funcName];
 
 exports.prototype._getRequestOptions = function(method, timeStamp, module, action, useJSON)
 {
     return {
         url : "https://" + this.configuration.getHostname(module) +
-              this.configuration.buildPath(module,action) + 
+              this.configuration.buildPath(module,action) +
               (useJSON ? ".json" : ""),
         method : method,
         qs : {
@@ -107,7 +109,7 @@ exports.prototype._getRequestOptions = function(method, timeStamp, module, actio
             oauth_nonce : this._generateNonceFor(timeStamp),
             oauth_signature_method : "HMAC-SHA1",
             oauth_timestamp : Math.floor(timeStamp.getTime()/1000),
-            oauth_version : "1.0" // Yes, needs to be a string (otherwise gets truncated)  
+            oauth_version : "1.0" // Yes, needs to be a string (otherwise gets truncated)
         },
         headers : {},
     };
@@ -123,10 +125,10 @@ exports.prototype._generateNonceFor = function(timeStamp)
     var maxRand = 2147483647.0;  // This constant comes from PHP, IIRC
     var rand = Math.round(Math.random() * maxRand);
 
-    var microtimeString = "" + msSinceSecond + "00000 " + secondsSinceEpoch;   
+    var microtimeString = "" + msSinceSecond + "00000 " + secondsSinceEpoch;
     var nonce = microtimeString + rand;
 
-    var md5Hash = crypto.createHash('md5');    
+    var md5Hash = crypto.createHash('md5');
     md5Hash.update(nonce);
     return md5Hash.digest('hex');
 };
@@ -167,24 +169,24 @@ exports.prototype._buildParamsDescriptor = function(paramsDescriptorArray)
         var name = paramsDescriptorArray[index];
         var required = paramsDescriptorArray[index+1];
         var validator = paramsDescriptorArray[index+2];
-        
+
         if (typeof(name) != "string") throw "Invalid 'name' in ParamsDescriptor!";
         else if (typeof(required) != "boolean" && typeof(required) != "function")
             throw "Invalid 'required' in ParamsDescriptor!";
         else if (typeof(validator) != "function")
             throw "Invalid 'validator' in ParamsDescriptor!";
-        
+
         index += 3;
-        
+
         paramsDescriptor.push({ name:name, required:required, validator:validator });
     }
-    
+
     return paramsDescriptor;
 };
 
-exports.prototype._validateAsString = function(val) 
-{ 
-    return { valid:true, value:String(val)}; 
+exports.prototype._validateAsString = function(val)
+{
+    return { valid:true, value:String(val)};
 };
 
 exports.prototype._validateAsBool = function(val)
@@ -192,10 +194,10 @@ exports.prototype._validateAsBool = function(val)
     return { valid:(typeof(val) == "Boolean"), value:Boolean(val) };
 };
 
-exports.prototype._validateAsInt = function(val) 
-{ 
-    var newVal = parseInt(val); 
-    return { valid:!isNaN(newVal), value:newVal}; 
+exports.prototype._validateAsInt = function(val)
+{
+    var newVal = parseInt(val);
+    return { valid:!isNaN(newVal), value:newVal};
 };
 
 exports.prototype._validateAsFloat = function(val)
@@ -214,7 +216,7 @@ exports.prototype._validateAsOneOf = function(val,permittedValues)
 {
     if (arguments.length < 2) // Simplifies usage of this validator
         return function(v) { return this._validateAsOneOf(v,val); }.bind(this);
-        
+
     var valid = false;
     for (var index = 0; index < permittedValues.length && !valid; ++index)
         valid = (val == permittedValues[index]);
@@ -237,8 +239,8 @@ exports.prototype._validateParams = function(paramsDescriptor,params)
     for (var paramDescriptor in paramsDescriptor)
     {
         var name = paramDescriptor.name;
-        var isParamRequired = typeof paramDescriptor == "function" ? 
-                                 paramDescriptor.required(params) : 
+        var isParamRequired = typeof paramDescriptor == "function" ?
+                                 paramDescriptor.required(params) :
                                  paramDescriptor.required;
         var isParamPresent = name in params;
         if (isParamRequired && !isParamPresent)
@@ -258,7 +260,7 @@ exports.prototype._validateParams = function(paramsDescriptor,params)
             }
         }
     }
-    
+
     return "";
 };
 
@@ -294,28 +296,28 @@ exports.prototype._run = function(actionDescriptor,params,successCallback,errorC
 {
     if (typeof(successCallback) != "function" || typeof(errorCallback) != "function")
         throw "One or more callback is not a function!";
-    
+
     if (!this.authorized)
         return errorCallback("Please authorize first!");
-    
+
     // Generate the options for the request module
     var requestOptions = this._getRequestOptions(actionDescriptor.method,
                                                   new Date(),
                                                   actionDescriptor.module,
                                                   actionDescriptor.action,
                                                   actionDescriptor.useJSON);
-    
+
     // Add our token
     requestOptions.qs.oauth_token = this.configuration.oauth.access_token;
-    
+
     if (actionDescriptor.method == "GET")
     {
         // Add this call's query parameters
         for (var paramName in params)
             requestOptions.qs[paramName] = params[paramName];
-        
+
         requestOptions.headers["Authorization"] = this._getAuthorizationHeaderFor(requestOptions);
-        
+
         // Override query string with just the query params
         requestOptions.qs = params;
     }
@@ -327,40 +329,50 @@ exports.prototype._run = function(actionDescriptor,params,successCallback,errorC
                                                             "application/json" :
                                                             "application/x-www-form-urlencoded";
 
-        requestOptions.headers["Authorization"] = this._getAuthorizationHeaderFor(requestOptions); 
+        requestOptions.headers["Authorization"] = this._getAuthorizationHeaderFor(requestOptions);
 
         //console.log("Authorization: " + requestOptions.headers["Authorization"]);
 
         requestOptions.qs = {}; // Clear query string (we don't use it in POST requests)
-        
+
         if (actionDescriptor.method == "POST")
             requestOptions.body = actionDescriptor.useJSON ?
                                         JSON.stringify(params) :
                                         querystring.stringify(params);
     }
-    
+
     // Make the request
     var qs = querystring.stringify(requestOptions.qs);
-    console.log("Request: [" + requestOptions.method + "]: " + requestOptions.url + (qs.length ? "?" + qs : ""));
+
+    if(options.verbose) {
+        console.log("Request: [" + requestOptions.method + "]: " + requestOptions.url + (qs.length ? "?" + qs : ""));
+    }
+
     this.request(requestOptions,function(error,message,body)
     {
-        if (error) 
-        { 
-            console.error("Error received in etrade::_run(): " + error); 
-            errorCallback(error); 
+        if (error)
+        {
+            if(options.verbose) {
+                console.error("Error received in etrade::_run(): " + error);
+            }
+
+            errorCallback(error);
         }
         else if (message.statusCode != 200)
         {
-            console.error("E*TRADE returned status code: " + message.statusCode);
-            var msg = { body:body, httpVersion:message.httpVersion, 
+            if(options.verbose) {
+                console.error("E*TRADE returned status code: " + message.statusCode);
+            }
+
+            var msg = { body:body, httpVersion:message.httpVersion,
                         headers:message.headers, statusCode:message.statusCode };
-            
+
             errorCallback("E*TRADE responded with a non-OK HTTP status code: " + JSON.stringify(msg));
         }
         else
-        { 
+        {
             var response = this._parseBody(message.headers["content-type"],body);
-            successCallback(response); 
+            successCallback(response);
         }
     }.bind(this));
 };

--- a/lib/etrade.js
+++ b/lib/etrade.js
@@ -20,8 +20,8 @@ module.exports = exports = function(options)
         throw Error("The etrade module requires specification of an API secret");
     if (!options.hasOwnProperty("useSandbox"))
         options.useSandbox = true;
-    if (!options.hasOwnProperty("verbose"))
-        options.verbose = false;
+    if (!options.hasOwnProperty("verboseLogging"))
+        options.verboseLogging = false;
 
     var configurations =
     {
@@ -344,7 +344,7 @@ exports.prototype._run = function(actionDescriptor,params,successCallback,errorC
     // Make the request
     var qs = querystring.stringify(requestOptions.qs);
 
-    if(options.verbose) {
+    if(options.verboseLogging) {
         console.log("Request: [" + requestOptions.method + "]: " + requestOptions.url + (qs.length ? "?" + qs : ""));
     }
 
@@ -352,7 +352,7 @@ exports.prototype._run = function(actionDescriptor,params,successCallback,errorC
     {
         if (error)
         {
-            if(options.verbose) {
+            if(options.verboseLogging) {
                 console.error("Error received in etrade::_run(): " + error);
             }
 
@@ -360,7 +360,7 @@ exports.prototype._run = function(actionDescriptor,params,successCallback,errorC
         }
         else if (message.statusCode != 200)
         {
-            if(options.verbose) {
+            if(options.verboseLogging) {
                 console.error("E*TRADE returned status code: " + message.statusCode);
             }
 

--- a/lib/etrade.js
+++ b/lib/etrade.js
@@ -21,7 +21,7 @@ module.exports = exports = function(options)
     if (!options.hasOwnProperty("useSandbox"))
         options.useSandbox = true;
     if (!options.hasOwnProperty("verboseLogging"))
-        options.verboseLogging = false;
+        options.verboseLogging = true;
 
     var configurations =
     {


### PR DESCRIPTION
Put the excessive request and error logging under a flag which defaults to `true`. If you wish to disable the verbose logging:

```
{
  useSandbox : false,
  key : 'your_key',
  secret : 'your_secret',
  verboseLogging: false
}
```